### PR TITLE
Always ensure we have some spacing between Nodes in a tree

### DIFF
--- a/tree/tree.go
+++ b/tree/tree.go
@@ -95,6 +95,10 @@ func Sprint(root Node) string {
 			}
 
 			spaces := paddings[n] - covered
+			// Should always have some spacing
+			if spaces < 0 {
+				spaces = 1
+			}
 			data := fmt.Sprintf("%v", n.Data())
 			nodes += strings.Repeat(" ", spaces) + data
 


### PR DESCRIPTION
Without asserting that we have some space, there is an edge case that
forces the space count to drop below zero, causing strings.Repeat to
panic and crash:

```
panic: strings: negative Repeat count

goroutine 1 [running]:
strings.Repeat(0x743c40, 0x1, 0xffffffffffffffe9, 0x1, 0x1)
        /usr/lib/golang/src/strings/strings.go:533 +0x5ca
github.com/shivamMg/ppds/tree.Sprint(0x7af040, 0xc000498510, 0xc0000ba2e0, 0x0)
        /go/src/github.com/shivamMg/ppds/tree/tree.go:99 +0x3d5
github.com/shivamMg/ppds/tree.Print(0x7af040, 0xc000498510)
        /go/src/github.com/shivamMg/ppds/tree/tree.go:63 +0x39
```